### PR TITLE
fix (ibu): intermittent delivery status of Ibu

### DIFF
--- a/opensrp-bidan/build.gradle
+++ b/opensrp-bidan/build.gradle
@@ -49,7 +49,7 @@ android {
         minSdkVersion 18
         targetSdkVersion 27
         versionCode 8
-        versionName "8.4.1"
+        versionName "8.4.2"
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
         ndk { abiFilters "armeabi", "armeabi-v7a", "x86" }

--- a/opensrp-bidan/build.gradle
+++ b/opensrp-bidan/build.gradle
@@ -49,7 +49,7 @@ android {
         minSdkVersion 18
         targetSdkVersion 27
         versionCode 8
-        versionName "8.4.2"
+        versionName "8.4.3"
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
         ndk { abiFilters "armeabi", "armeabi-v7a", "x86" }

--- a/opensrp-bidan/build.gradle
+++ b/opensrp-bidan/build.gradle
@@ -49,7 +49,7 @@ android {
         minSdkVersion 18
         targetSdkVersion 27
         versionCode 8
-        versionName "8.4.3"
+        versionName "8.4.4"
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
         ndk { abiFilters "armeabi", "armeabi-v7a", "x86" }

--- a/opensrp-bidan/src/main/assets/www/form/kartu_pnc_visit/form_definition.json
+++ b/opensrp-bidan/src/main/assets/www/form/kartu_pnc_visit/form_definition.json
@@ -88,6 +88,14 @@
         "bind": "/model/instance/PNC_visit_reviewed/tanda_vital_suhu"
       },
       {
+        "name": "tandaVitalNadi",
+        "bind": "/model/instance/PNC_visit_reviewed/tanda_vital_nadi"
+      },
+      {
+        "name": "tandaVitalPernafasan",
+        "bind": "/model/instance/PNC_visit_reviewed/tanda_vital_pernafasan"
+      },
+      {
         "name": "pelayananfe",
         "bind": "/model/instance/PNC_visit_reviewed/pelayananfe"
       },

--- a/opensrp-bidan/src/main/java/org/smartregister/bidan/provider/KIClientsProvider.java
+++ b/opensrp-bidan/src/main/java/org/smartregister/bidan/provider/KIClientsProvider.java
@@ -113,7 +113,8 @@ public class KIClientsProvider extends BaseClientsProvider {
         TextView children_age_right = (TextView) convertView.findViewById(R.id.txt_children_age_right);
         TextView children_age_bottom = (TextView) convertView.findViewById(R.id.txt_children_age_bottom);
 
-        edd_due.setText("");
+//        edd_due.setText("");
+        String eddDueStr = "";
         anc_status_layout.setText("");
         date_status.setText("");
         visit_status.setText("");
@@ -140,10 +141,12 @@ public class KIClientsProvider extends BaseClientsProvider {
                 _dueEdd = mContext.getString(R.string.edd_passed);
             }
 
-            edd_due.setText(_dueEdd);
+//            edd_due.setText(_dueEdd);
+            eddDueStr = _dueEdd;
 
         } else {
-            edd_due.setText("");
+//            edd_due.setText("");
+            eddDueStr = "";
         }
 
         if (ibuparent != null) {
@@ -173,16 +176,19 @@ public class KIClientsProvider extends BaseClientsProvider {
                   /*  checkMonth("delivered",edd_due);*/
                         edd_due.setTextColor(mContext.getResources().getColor(R.color.alert_complete_green));
                         String deliver = mContext.getString(R.string.delivered);
-                        edd_due.setText(deliver);
+//                        edd_due.setText(deliver);
+                        eddDueStr = deliver;
                         checkLastVisit(pc.getDetails().get("PNCDate"), mContext.getString(R.string.pnc_ke) + " " + pc.getDetails().get("hariKeKF"), mContext.getString(R.string.service_pnc),
                                 anc_status_layout, date_status, visit_status);
                     }else{
                         ((TextView) convertView.findViewById(R.id.txt_edd)).setText("");
-                        edd_due.setText("");
+//                        edd_due.setText("");
+                        eddDueStr = "";
                     }
                 }else{
                     ((TextView) convertView.findViewById(R.id.txt_edd)).setText("");
-                    edd_due.setText("");
+//                    edd_due.setText("");
+                    eddDueStr = "";
                 }
 
             }
@@ -193,6 +199,7 @@ public class KIClientsProvider extends BaseClientsProvider {
                         mContext.getString(R.string.fp_methods) + ": " + pc.getDetails().get("jenisKontrasepsi"),
                         mContext.getString(R.string.service_fp), anc_status_layout, date_status, visit_status);
             }
+        edd_due.setText(eddDueStr);
 
         //anak
         for (int i = 0; i < allchild.size(); i++) {


### PR DESCRIPTION
**The Cause**

1. Client (the application) does:
- ANC: event date: 15 Feb 2019
- Dokumentasi Persalinan: event date: 15 Feb 2019

2. Sync (upload):
ANC and Dokumentasi Persalinan (delivery document) will be sent, and the server will add the same time for dateCreated. Because it's a bulky transaction.

3. Sync (download), sometimes like this:
Dokumentasi Persalinan data is above ANC. Because the date is the same, so no order (sorted by), and the data can be flipped.
While in the client (application), Dokumentasi Persalinan is processed first, then ANC.
That's why the status is still ANC (EDD Passed).

**The Fix**

When there are both ANC and Dokumentasi Persalinan, with actually it's a sequence, so the status should be Dokumentasi Persalinan (delivered).

https://github.com/OpenSRP/opensrp-client-sid/issues/32